### PR TITLE
Set gas limit to call IBTP.getValue inside try/catch{}

### DIFF
--- a/contracts/infrastructure/price/PriceCalculator.sol
+++ b/contracts/infrastructure/price/PriceCalculator.sol
@@ -195,7 +195,7 @@ contract PriceCalculator is Initializable, ControllableV2, IPriceCalculator {
 
   function isBPT(address token) public view returns (bool) {
     IBPT bpt = IBPT(token);
-    try bpt.getVault() returns (address vault){
+    try bpt.getVault{gas : 3000}() returns (address vault){
       return (vault == BEETHOVEN_VAULT_FANTOM
       || vault == BALANCER_VAULT_ETHEREUM);
     } catch {}


### PR DESCRIPTION
Set gas limit 3000 for call
` try   bpt.getVault()   ...  catch {}`
inside PriceCalculator.isBPT.

Otherwise there is high gas consumption possible (sushi-ut is not passed)