### PR TITLE
Set autocompound 90% for curve and spooky strategies

### DIFF
--- a/contracts/base/strategies/curve/CurveStrategyBase.sol
+++ b/contracts/base/strategies/curve/CurveStrategyBase.sol
@@ -30,12 +30,12 @@ abstract contract CurveStrategyBase is StrategyBase, ICurveStrategy {
 
   /// @notice Version of the contract
   /// @dev Should be incremented when contract changed
-  string public constant VERSION = "1.0.3";
+  string public constant VERSION = "1.0.4";
   /// @notice Strategy type for statistical purposes
   string public constant override STRATEGY_NAME = "CurveStrategyBase";
 
-  /// @dev 1% buyback
-  uint256 private constant _BUY_BACK_RATIO = 100;
+  /// @dev 10% buyback
+  uint256 private constant _BUY_BACK_RATIO = 1000;
 
   /// @notice Curve gauge rewards pool
   address public override gauge;

--- a/contracts/base/strategies/masterchef-base/SpookyStrategyACBase.sol
+++ b/contracts/base/strategies/masterchef-base/SpookyStrategyACBase.sol
@@ -25,9 +25,9 @@ abstract contract SpookyStrategyACBase is StrategyBase {
   string public constant override STRATEGY_NAME = "SpookyStrategyACBase";
   /// @notice Version of the contract
   /// @dev Should be incremented when contract changed
-  string public constant VERSION = "1.0.0";
-  /// @dev 1% buyback
-  uint256 private constant _BUY_BACK_RATIO = 100;
+  string public constant VERSION = "1.0.1";
+  /// @dev 10% buyback
+  uint256 private constant _BUY_BACK_RATIO = 1000;
 
   /// @notice MasterChef rewards pool
   address public pool;


### PR DESCRIPTION
Buy back ratio was changed from 100 to 1000 for Curve and Spooky strategies.

Spooky unit tests were passed.
Curve unit tests were passed with following .env settings:
TETU_FTM_RPC_URL=Https://rpc.fantom.network
TETU_FTM_FORK_BLOCK=34029057