### PR TITLE
Amb claim script, scan tool

### DIFF
--- a/scan.cmd
+++ b/scan.cmd
@@ -1,0 +1,32 @@
+@echo off
+rem To use this script, firstly do:
+rem npm install -g @owodunni/ethscan
+
+rem add your scan key to env variables outside this file
+rem SET ETHSCAN_KEY=
+
+SET ETHSCAN_URL=https://api.polygonscan.com
+IF "%~2"=="main" (
+SET ETHSCAN_URL=
+)
+IF "%~2"=="fantom" (
+SET ETHSCAN_URL=https://fantomscan.com // !!!!  NOT TESTED YET
+)
+IF "%~2"=="bsc" (
+SET ETHSCAN_URL=https://bscscan.com // !!!!  NOT TESTED YET
+)
+
+IF "%~1"=="" (
+ECHO "Usage: scan <contract_address> [main|fantom|bsc|matic]"
+ECHO "Contracts sources will be saved to ./tmp/<address> folder"
+ECHO "Polygon (matic) network used by default"
+ECHO "Ex: scan 0x255707b70bf90aa112006e1b07b9aea6de021424"
+ECHO
+REM Install the ethscan tool
+npm install -g @owodunni/ethscan
+
+) ELSE (
+
+CALL ethscan code %1 -o ./tmp/%1
+
+)

--- a/scripts/utils/balancer-claim/claim.js
+++ b/scripts/utils/balancer-claim/claim.js
@@ -35,7 +35,7 @@ async function ipfsGet(
 
 async function getSnapshot(network, token) {
   let snapshot
-  if (network == 'matic') {
+  if (network == 'polygon') {
     if (token == '0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3'){
       snapshot = constants.snapshotBalPoly
     } else if (token == '0x2e1AD108fF1D8C782fcBbB89AAd783aC49586756') {
@@ -128,8 +128,10 @@ async function claimRewards(
   try {
     const claims = pendingClaims.map(week => {
       const claimBalance = week.amount;
+      console.log('claimBalance', claimBalance);
       const merkleTree = loadTree(reports[week.id]);
       const distributor = week.distributor;
+      console.log('distributor', distributor);
 
       const proof = merkleTree.getHexProof(
         soliditySha3(account, toWei(claimBalance))
@@ -137,12 +139,15 @@ async function claimRewards(
       return [parseInt(week.id), toWei(claimBalance), distributor, 0, proof];
     });
     let merkleAddress, balToken, priorityFee;
-    if (network == 'matic') {
+    if (network == 'polygon') {
       merkleAddress = constants.merkleOrchardPoly;
     } else {
       merkleAddress = constants.merkleOrchardEth;
     }
     const merkleContract = await ethers.getContractAt("IMerkleOrchard", merkleAddress);
+    console.log('account', account);
+    console.log('token', token);
+    console.log('claims', claims);
     // const result = await type2Transaction(network, merkleContract.claimDistributions, account, claims, [token]);
     const result = await merkleContract.claimDistributions(account, claims, [token]);
     return result;

--- a/scripts/utils/balancer-claim/run.js
+++ b/scripts/utils/balancer-claim/run.js
@@ -5,17 +5,17 @@ const accountsEth = [
 ];
 
 const accountsPoly = [
+  // // AMB 1.0 BAL Pipes
+  // "0xcacD584EF2815E066C8A507E26D3592a41c7DF4A", // AMB WETH
+  // "0xF710277064c49f4689f061B4263d8930E395C61d", // AMB MATIC
+  // "0x88f0b9F9B97f8A02508E4E69d46B619fc385c5f4", // AMB AAVE
+  // "0x42d68D48120333720FbA4B079f47240b6FdEcef2", // AMB WBTC
+
   // AMB 2.0 BAL Pipes
   "0x4bfe2eAc4c8e07fBfCD0D5A003A78900F8e0B589", // AMB WETH
   "0x62E3A5d0321616B73CCc890a5D894384020B768D", // AMB MATIC
   "0xf5c30eC17BcF3C34FB515EC68009e5da28b5D06F", // AMB AAVE
   "0xA69967d315d7add8222aEe81c1F178dAc0017089", // AMB WBTC
-
-  // AMB 1.0 BAL Pipes
-  "0xcacD584EF2815E066C8A507E26D3592a41c7DF4A", // AMB WETH
-  "0xF710277064c49f4689f061B4263d8930E395C61d", // AMB MATIC
-  "0x88f0b9F9B97f8A02508E4E69d46B619fc385c5f4", // AMB AAVE
-  "0x42d68D48120333720FbA4B079f47240b6FdEcef2", // AMB WBTC
 ];
 
 const BAL_TOKEN = '0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3';
@@ -35,10 +35,10 @@ const weeksEth = [73, 74];
 const weeksPoly = [];
 const firstWeek = 1
 const lastWeek = 27
-for (var i = 1; i <= lastWeek; i++) weeksPoly.push(i);
+for (let i = firstWeek; i <= lastWeek; i++) weeksPoly.push(i);
 
 let accounts;
-if (network == 'polygon') {
+if (network === 'polygon') {
   accounts = accountsPoly;
   weeks = weeksPoly;
   tokens = tokensPoly;
@@ -66,9 +66,9 @@ async function claimBal() {
       let pendingClaims = {claims: [], reports: []};
       for (l = 0; l < weeks.length; l++) {
         let week = weeks[l];
-        if (token == TUSD_TOKEN) {
+        if (token === TUSD_TOKEN) {
           week = week - 5;
-        } else if (token == QI_TOKEN) {
+        } else if (token === QI_TOKEN) {
           week = week - 15;
         }
         if (week < 1) {
@@ -103,7 +103,7 @@ async function claimBal() {
       console.log("Total amount:", totalAmount);
       console.log("for account :", account);
 
-      if (totalAmount < 50 && network == 'eth') {
+      if (totalAmount < 50 && network === 'eth') {
         console.log("Total claim amount too small");
         continue;
       }

--- a/scripts/utils/balancer-claim/run.js
+++ b/scripts/utils/balancer-claim/run.js
@@ -1,60 +1,82 @@
-// tslint:disable-next-line:no-var-requires
 const Claim = require("./claim.js");
+const {ethers} = require("hardhat");
 
-const {ethers, network } = require("hardhat");
-
-const accounts = [
-  // // AMB 2.0 BAL Pipes
-  // "0x4bfe2eAc4c8e07fBfCD0D5A003A78900F8e0B589", // AMB WETH
-  // "0x62E3A5d0321616B73CCc890a5D894384020B768D", // AMB MATIC
-  // "0xf5c30eC17BcF3C34FB515EC68009e5da28b5D06F", // AMB AAVE
-  // "0xA69967d315d7add8222aEe81c1F178dAc0017089", // AMB WBTC
-
-  // // AMB 1.0 BAL Pipes
-  // "0xcacD584EF2815E066C8A507E26D3592a41c7DF4A", // AMB WETH
-  // "0xF710277064c49f4689f061B4263d8930E395C61d", // AMB MATIC
-  // "0x88f0b9F9B97f8A02508E4E69d46B619fc385c5f4", // AMB AAVE
-  // "0x42d68D48120333720FbA4B079f47240b6FdEcef2", // AMB WBTC
+const accountsEth = [
 ];
 
-const tokens = [
-  '0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3', // BAL
-  // '0x2e1AD108fF1D8C782fcBbB89AAd783aC49586756', // TUSD
-  // '0x580A84C73811E1839F75d86d75d88cCa0c241fF4', // QI
+const accountsPoly = [
+  // AMB 2.0 BAL Pipes
+  "0x4bfe2eAc4c8e07fBfCD0D5A003A78900F8e0B589", // AMB WETH
+  "0x62E3A5d0321616B73CCc890a5D894384020B768D", // AMB MATIC
+  "0xf5c30eC17BcF3C34FB515EC68009e5da28b5D06F", // AMB AAVE
+  "0xA69967d315d7add8222aEe81c1F178dAc0017089", // AMB WBTC
+
+  // AMB 1.0 BAL Pipes
+  "0xcacD584EF2815E066C8A507E26D3592a41c7DF4A", // AMB WETH
+  "0xF710277064c49f4689f061B4263d8930E395C61d", // AMB MATIC
+  "0x88f0b9F9B97f8A02508E4E69d46B619fc385c5f4", // AMB AAVE
+  "0x42d68D48120333720FbA4B079f47240b6FdEcef2", // AMB WBTC
 ];
 
+const BAL_TOKEN = '0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3';
+const TUSD_TOKEN = '0x2e1AD108fF1D8C782fcBbB89AAd783aC49586756';
+const QI_TOKEN = '0x580A84C73811E1839F75d86d75d88cCa0c241fF4';
+const tokensPoly = [
+  // BAL_TOKEN,
+  // TUSD_TOKEN,
+  QI_TOKEN,
+];
 
-// const weekFirst = 1;
-const weekFirst = 1;
-const weekLast = 2; // TODO 27
-console.log('weeks from', weekFirst, 'to', weekLast);
+const DENOMINATOR = ethers.BigNumber.from(10).pow(10);
+const FIXED_POINTS = 10**8;
 
-console.log('network.name', network.name);
-const networkName = ['hardhat','matic'].includes(network.name)
-    ? 'polygon' : network.name; // use matic constants for hardhat forking
+const network = 'polygon';
+const weeksEth = [73, 74];
+const weeksPoly = [];
+const firstWeek = 1
+const lastWeek = 27
+for (var i = 1; i <= lastWeek; i++) weeksPoly.push(i);
 
+let accounts;
+if (network == 'polygon') {
+  accounts = accountsPoly;
+  weeks = weeksPoly;
+  tokens = tokensPoly;
+} else {
+  accounts = accountsEth;
+  weeks = weeksEth;
+  tokens = ['0xba100000625a3754423978a60c9317c58a424e3D'];
+}
 async function claimBal() {
-  console.log("Network:", networkName);
+  console.log("Network:", network);
   let totalRewards = 0;
   let totalClaimed = 0;
 
-  for (let j = 0; j < accounts.length; j++) {
+  for (j = 0; j < accounts.length; j++) {
     let account = accounts[j];
-    console.log("Account:", account, " - ", j+1, "/",accounts.length);
+    console.log("Account:", account, " - ", j+1, "/", accounts.length);
 
-    for (let k = 0; k < tokens.length; k++) {
+    for (k = 0; k < tokens.length; k++) {
       console.log("Fetching token");
       const token = tokens[k];
       console.log("Token:", token);
-      // const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
       let tokenContract = await ethers.getContractAt("ERC20", token);
 
       console.log("Fetching pending claims");
       let pendingClaims = {claims: [], reports: []};
-      for (let week = weekFirst; week <= weekLast; week++) {
+      for (l = 0; l < weeks.length; l++) {
+        let week = weeks[l];
+        if (token == TUSD_TOKEN) {
+          week = week - 5;
+        } else if (token == QI_TOKEN) {
+          week = week - 15;
+        }
+        if (week < 1) {
+          continue;
+        }
         console.log('week', week);
         try {
-          let pendingClaim = await Claim.getPendingClaims(account, week, networkName, token);
+          let pendingClaim = await Claim.getPendingClaims(account, week, network, token);
           if (pendingClaim) {
             pendingClaims.claims.push(pendingClaim.claim);
             pendingClaims.reports[week] = pendingClaim.report[week];
@@ -62,7 +84,7 @@ async function claimBal() {
         } catch (e) {
           console.warn('Error getting claims for week', week, 'Error:', e.message, typeof e)
           // week is not published, so break the cycle
-          break;
+          // break;
         }
       }
       console.log("Claims:");
@@ -74,35 +96,39 @@ async function claimBal() {
       }
 
       let totalAmount = 0;
-      for (let i = 0; i < pendingClaims.claims.length; i++) {
+      for (i = 0; i < pendingClaims.claims.length; i++) {
         totalAmount += Number(pendingClaims.claims[i]['amount']);
       }
       totalRewards += totalAmount;
       console.log("Total amount:", totalAmount);
       console.log("for account :", account);
 
-      let balanceBefore = await tokenContract.balanceOf(account);
-      console.log('network.name', network.name);
-      // if (network.name !== 'hardhat') { // TODO remove
-        console.log("Making claims");
+      if (totalAmount < 50 && network == 'eth') {
+        console.log("Total claim amount too small");
+        continue;
+      }
 
-        let claim = await Claim.claimRewards(account, pendingClaims.claims, pendingClaims.reports, networkName, token);
-        console.log("tx:", claim.hash);
-        await claim.wait();
-        console.log("tx mined");
-      // } else console.log('Claim skipped.')
+      console.log("Making claims");
+      let balanceBefore = await tokenContract.balanceOf(account);
+      console.log('balanceBefore', balanceBefore.toString());
+      let claim = await Claim.claimRewards(account, pendingClaims.claims, pendingClaims.reports, network, token);
+      console.log("tx:", claim.hash);
+      await claim.wait();
+      console.log("tx mined");
 
       let balanceAfter = await tokenContract.balanceOf(account);
-      const fixed = 8;
-      const claimed = (balanceAfter.sub(balanceBefore).div(10**(18-fixed))).toNumber() / 10**fixed;
-      console.log("++++ Claimed:", claimed/*.toFixed(fixed)*/);
+      console.log('balanceAfter', balanceAfter.toString());
+      const claimed = balanceAfter.sub(balanceBefore).div(DENOMINATOR).toNumber();
+      console.log("tx:", claim.hash);
+      console.log("+++Claimed:", claimed/FIXED_POINTS);
+      console.log("---------------");
       totalClaimed += claimed;
-
+      console.log('totalClaimed', totalClaimed/FIXED_POINTS);
     }
   }
   console.log('totalRewards for all accounts', totalRewards);
-  console.log('totalClaimed for all accounts', totalClaimed);
+  console.log('totalClaimed for all accounts', totalClaimed/FIXED_POINTS);
 }
 
-claimBal().then();
+claimBal().then()
 // module.exports = {claimBal}

--- a/scripts/utils/balancer-claim/run.js
+++ b/scripts/utils/balancer-claim/run.js
@@ -22,8 +22,8 @@ const BAL_TOKEN = '0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3';
 const TUSD_TOKEN = '0x2e1AD108fF1D8C782fcBbB89AAd783aC49586756';
 const QI_TOKEN = '0x580A84C73811E1839F75d86d75d88cCa0c241fF4';
 const tokensPoly = [
-  // BAL_TOKEN,
-  // TUSD_TOKEN,
+  BAL_TOKEN,
+  // TUSD_TOKEN, // AMB not rewarded with TUSD
   QI_TOKEN,
 ];
 
@@ -34,7 +34,7 @@ const network = 'polygon';
 const weeksEth = [73, 74];
 const weeksPoly = [];
 const firstWeek = 1
-const lastWeek = 27
+const lastWeek = 28
 for (let i = firstWeek; i <= lastWeek; i++) weeksPoly.push(i);
 
 let accounts;

--- a/scripts/utils/balancer-claim/run.js
+++ b/scripts/utils/balancer-claim/run.js
@@ -1,16 +1,14 @@
 // tslint:disable-next-line:no-var-requires
 const Claim = require("./claim.js");
-// tslint:disable-next-line:no-var-requires
-const BigNumber = require("bignumber.js");
 
 const {ethers, network } = require("hardhat");
 
 const accounts = [
   // // AMB 2.0 BAL Pipes
-  "0x4bfe2eAc4c8e07fBfCD0D5A003A78900F8e0B589", // AMB WETH
-  "0x62E3A5d0321616B73CCc890a5D894384020B768D", // AMB MATIC
-  "0xf5c30eC17BcF3C34FB515EC68009e5da28b5D06F", // AMB AAVE
-  "0xA69967d315d7add8222aEe81c1F178dAc0017089", // AMB WBTC
+  // "0x4bfe2eAc4c8e07fBfCD0D5A003A78900F8e0B589", // AMB WETH
+  // "0x62E3A5d0321616B73CCc890a5D894384020B768D", // AMB MATIC
+  // "0xf5c30eC17BcF3C34FB515EC68009e5da28b5D06F", // AMB AAVE
+  // "0xA69967d315d7add8222aEe81c1F178dAc0017089", // AMB WBTC
 
   // // AMB 1.0 BAL Pipes
   // "0xcacD584EF2815E066C8A507E26D3592a41c7DF4A", // AMB WETH
@@ -26,13 +24,14 @@ const tokens = [
 ];
 
 
-// TODO remove comment
 // const weekFirst = 1;
-const weekFirst = 25;
-const weekLast = 999;
+const weekFirst = 1;
+const weekLast = 2; // TODO 27
 console.log('weeks from', weekFirst, 'to', weekLast);
 
-const networkName = network.name === 'hardhat' ? 'matic' : network.name; // use matic constants for forking
+console.log('network.name', network.name);
+const networkName = ['hardhat','matic'].includes(network.name)
+    ? 'polygon' : network.name; // use matic constants for hardhat forking
 
 async function claimBal() {
   console.log("Network:", networkName);
@@ -80,19 +79,18 @@ async function claimBal() {
       }
       totalRewards += totalAmount;
       console.log("Total amount:", totalAmount);
+      console.log("for account :", account);
 
-      console.log("Making claims");
       let balanceBefore = await tokenContract.balanceOf(account);
+      console.log('network.name', network.name);
+      // if (network.name !== 'hardhat') { // TODO remove
+        console.log("Making claims");
 
-      // impersonate account to test claims
-      if (network.name === 'hardhat') {
-
-      }
-
-      let claim = await Claim.claimRewards(account, pendingClaims.claims, pendingClaims.reports, networkName, token);
-      console.log("tx:", claim.hash);
-      await claim.wait();
-      console.log("tx mined");
+        let claim = await Claim.claimRewards(account, pendingClaims.claims, pendingClaims.reports, networkName, token);
+        console.log("tx:", claim.hash);
+        await claim.wait();
+        console.log("tx mined");
+      // } else console.log('Claim skipped.')
 
       let balanceAfter = await tokenContract.balanceOf(account);
       const fixed = 8;

--- a/scripts/utils/balancer-claim/run.js
+++ b/scripts/utils/balancer-claim/run.js
@@ -5,13 +5,7 @@ const accountsEth = [
 ];
 
 const accountsPoly = [
-  // // AMB 1.0 BAL Pipes
-  // "0xcacD584EF2815E066C8A507E26D3592a41c7DF4A", // AMB WETH
-  // "0xF710277064c49f4689f061B4263d8930E395C61d", // AMB MATIC
-  // "0x88f0b9F9B97f8A02508E4E69d46B619fc385c5f4", // AMB AAVE
-  // "0x42d68D48120333720FbA4B079f47240b6FdEcef2", // AMB WBTC
-
-  // AMB 2.0 BAL Pipes
+   // AMB 2.0 BAL Pipes
   "0x4bfe2eAc4c8e07fBfCD0D5A003A78900F8e0B589", // AMB WETH
   "0x62E3A5d0321616B73CCc890a5D894384020B768D", // AMB MATIC
   "0xf5c30eC17BcF3C34FB515EC68009e5da28b5D06F", // AMB AAVE
@@ -32,9 +26,10 @@ const FIXED_POINTS = 10**8;
 
 const network = 'polygon';
 const weeksEth = [73, 74];
+
 const weeksPoly = [];
-const firstWeek = 1
-const lastWeek = 28
+const firstWeek = 26;
+const lastWeek = 28;
 for (let i = firstWeek; i <= lastWeek; i++) weeksPoly.push(i);
 
 let accounts;


### PR DESCRIPTION
I've added scan tool:
`scan <address> [network:main|fantom|matic]`
matic is default network

ex:+
`>scan 0x62E3A5d0321616B73CCc890a5D894384020B768D`

fetches all contract sources to `./tmp/0x62E3A5d0321616B73CCc890a5D894384020B768D`

to install npm modules firstly run without params
